### PR TITLE
fix: prevent infinite SWR retry loop on profile API 404 errors

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -72,8 +72,21 @@ function FreemiumBanner({ onClose }: { onClose: () => void }) {
 function UserMenu() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { data: user } = useSWR('/api/user', fetcher);
-  const { data: centerProfile } = useSWR('/api/profile/center', fetcher);
-  const { data: juryProfile } = useSWR('/api/profile/jury', fetcher);
+  
+  // Only fetch profiles based on user type to avoid 404 errors
+  const shouldFetchCenter = user?.user_type === 'centre';
+  const shouldFetchJury = user?.user_type === 'jury';
+  
+  const { data: centerProfile } = useSWR(
+    shouldFetchCenter ? '/api/profile/center' : null, 
+    fetcher,
+    { shouldRetryOnError: false }
+  );
+  const { data: juryProfile } = useSWR(
+    shouldFetchJury ? '/api/profile/jury' : null, 
+    fetcher,
+    { shouldRetryOnError: false }
+  );
   const router = useRouter();
 
   async function handleSignOut() {


### PR DESCRIPTION
- Add conditional profile fetching based on user_type
- Only fetch center profile for centre users
- Only fetch jury profile for jury users
- Add shouldRetryOnError: false to prevent infinite retries
- Fixes client-side exception causing dashboard crashes