### PR TITLE
perf: optimize jury requests filtering for instant updates

### DIFF
--- a/app/(dashboard)/dashboard/requests/page.tsx
+++ b/app/(dashboard)/dashboard/requests/page.tsx
@@ -405,15 +405,13 @@ function JuryRequestsPage() {
 
   useEffect(() => {
     fetchRequests();
-  }, [statusFilter]);
+  }, []); // Remove statusFilter dependency to prevent refetch on filter change
 
   const fetchRequests = async () => {
     try {
       setLoading(true);
-      const params = new URLSearchParams();
-      if (statusFilter) params.append('status', statusFilter);
-      
-      const response = await fetch(`/api/jury-requests?${params.toString()}`);
+      // Fetch all requests without status filter for client-side filtering
+      const response = await fetch(`/api/jury-requests`);
       const result = await response.json();
       
       if (result.success) {
@@ -586,10 +584,17 @@ function JuryRequestsPage() {
     }
   };
 
-  const filteredRequests = requests.filter(request =>
-    request.training_centers.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-    request.certification_type.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  const filteredRequests = requests.filter(request => {
+    // Apply status filter
+    const matchesStatus = !statusFilter || request.status === statusFilter;
+    
+    // Apply search filter
+    const matchesSearch = !searchQuery || 
+      request.training_centers.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+      request.certification_type.toLowerCase().includes(searchQuery.toLowerCase());
+    
+    return matchesStatus && matchesSearch;
+  });
 
   if (loading) {
     return (


### PR DESCRIPTION
- Remove server-side filtering that caused page reloads on status changes
- Implement client-side filtering for both status and search queries
- Fetch all requests once on page load instead of refetching on filter changes
- Improve user experience with instant, responsive filtering
- Maintain real-time updates for accept/reject actions

Performance improvements:
- Eliminates unnecessary API calls on filter changes
- Provides smooth, instant filtering without page reloads
- Reduces server load and improves responsiveness